### PR TITLE
add one way to returning message with fire time

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,20 @@ messages were dealt with more immediately than "normal" actor messages, they cou
 
 The details on the configuration of a job is outlined below in the section '*Schedule Configuration*'.
 
+### Returning scheduled Fire Time
+
+Sometimes we need to know the trigger time, with which we can known which job instance is being processed. so when an error occours,we can recover that with the same event,because the event contains the fire time.
+
+Here is an example,using the case class MessageRequireFireTime wrapping the Tick message, which will send a `MessageWithFireTime(Tick,scheduledFireTime)` message to a `WorkerActor`:
+
+```scala
+case object Tick
+
+val worker = system.actorOf(Props[WorkerActor])
+
+QuartzSchedulerExtension(system).schedule("Every30Seconds", worker, MessageRequireFireTime(Tick))
+```
+
 
 ### Configuration of Quartz Scheduler
 

--- a/src/main/scala/MessageWithFireTime.scala
+++ b/src/main/scala/MessageWithFireTime.scala
@@ -1,0 +1,9 @@
+package com.typesafe.akka.extension.quartz
+import java.util.Date
+
+/**
+  * wrap msg with scheduledFireTime
+  */
+final case class MessageWithFireTime(msg: AnyRef, scheduledFireTime:Date)
+
+final case class MessageRequireFireTime(msg: AnyRef)

--- a/src/main/scala/QuartzJob.scala
+++ b/src/main/scala/QuartzJob.scala
@@ -81,7 +81,11 @@ class SimpleActorMessageJob extends Job {
        * JobDataMap uses AnyRef, while message can be any (though do we really want to support value classes?)
        * so this casting (and the initial save into the map) may involve boxing.
        **/
-      val msg = dataMap.get("message")
+      val msg = dataMap.get("message") match {
+        case MessageRequireFireTime(msg) =>
+          MessageWithFireTime(msg,context.getScheduledFireTime)
+        case msg => msg
+      }
       val log = Logging(logBus, this)
       log.debug("Triggering job '{}', sending '{}' to '{}'", key.getName, msg, receiver)
       receiver match {

--- a/src/main/scala/QuartzJob.scala
+++ b/src/main/scala/QuartzJob.scala
@@ -82,9 +82,9 @@ class SimpleActorMessageJob extends Job {
        * so this casting (and the initial save into the map) may involve boxing.
        **/
       val msg = dataMap.get("message") match {
-        case MessageRequireFireTime(msg) =>
-          MessageWithFireTime(msg,context.getScheduledFireTime)
-        case msg => msg
+        case MessageRequireFireTime(m) =>
+          MessageWithFireTime(m,context.getScheduledFireTime)
+        case any:Any => any
       }
       val log = Logging(logBus, this)
       log.debug("Triggering job '{}', sending '{}' to '{}'", key.getName, msg, receiver)


### PR DESCRIPTION
Sometimes we need to know the trigger time, with which we can calculate the delay of scheduling. So I submitted a pull