### PR TITLE
Add next/previous firing time to context message

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,11 @@ The details on the configuration of a job is outlined below in the section '*Sch
 
 ### Returning scheduled Fire Time
 
-Sometimes we need to know the trigger time, with which we can known which job instance is being processed. so when an error occours,we can recover that with the same event,because the event contains the fire time.
+There are situations where the fire time is helpful. For example, when an error occurs, we know which job trigger is 
+being processed and can be recovered.
 
-Here is an example,using the case class MessageRequireFireTime wrapping the Tick message, which will send a `MessageWithFireTime(Tick,scheduledFireTime)` message to a `WorkerActor`:
+Here is an example using the case class `MessageRequireFireTime` wrapping the `Tick` message.  This will send a
+`MessageWithFireTime(Tick,scheduledFireTime)` message to a `WorkerActor`:
 
 ```scala
 case object Tick
@@ -167,6 +169,16 @@ val worker = system.actorOf(Props[WorkerActor])
 QuartzSchedulerExtension(system).schedule("Every30Seconds", worker, MessageRequireFireTime(Tick))
 ```
 
+Here is another example using the case class `MessageRequireFireTimes` wrapping the `Tick` message.  This will send a
+`MessageWithFireTimes(Tick, previousFireTime, scheduledFireTime, nextFireTime)` message to a `WorkerActor`:
+
+```scala
+case object Tick
+
+val worker = system.actorOf(Props[WorkerActor])
+
+QuartzSchedulerExtension(system).schedule("Every30Seconds", worker, MessageRequireFireTimes(Tick))
+```
 
 ### Configuration of Quartz Scheduler
 
@@ -310,7 +322,7 @@ follows a time format of `HH:MM[:SS[:mmm]]` where:
     - SS is the **optional** second of the specified time, and must be in the range 0-59
     - mmm is the **optional** millisecond of the specified time, and must be in the range 0-999
 
-An example, which  doesn't allow jobs to run between 3AM and 5AM during the PST Timezone:
+An example, which doesn't allow jobs to run between 3AM and 5AM during the PST Timezone:
 
 ```
 HourOfTheWolf {

--- a/src/main/scala/MessageWithFireTime.scala
+++ b/src/main/scala/MessageWithFireTime.scala
@@ -4,6 +4,19 @@ import java.util.Date
 /**
   * wrap msg with scheduledFireTime
   */
-final case class MessageWithFireTime(msg: AnyRef, scheduledFireTime:Date)
 
-final case class MessageRequireFireTime(msg: AnyRef)
+trait FireTimeMessage {
+  def msg: AnyRef
+}
+
+final case class MessageWithFireTime(msg: AnyRef, scheduledFireTime:Date) extends FireTimeMessage
+final case class MessageWithFireTimes(msg: AnyRef, previousFiringTime: Option[Date], currentFiringTime: Option[Date], nextFiringTime: Option[Date]) extends FireTimeMessage
+
+trait FiringTimeField
+
+case object NextFiringTime extends FiringTimeField
+case object PreviousFiringTime extends FiringTimeField
+case object CurrentFiringTime extends FiringTimeField
+case object AllFiringTimes extends FiringTimeField
+
+final case class MessageRequireFireTime(msg: AnyRef, fields: FiringTimeField=CurrentFiringTime)

--- a/src/main/scala/QuartzJob.scala
+++ b/src/main/scala/QuartzJob.scala
@@ -82,8 +82,14 @@ class SimpleActorMessageJob extends Job {
        * so this casting (and the initial save into the map) may involve boxing.
        **/
       val msg = dataMap.get("message") match {
-        case MessageRequireFireTime(m) =>
-          MessageWithFireTime(m,context.getScheduledFireTime)
+        case MessageRequireFireTime(m, f) =>
+          f match {
+            case NextFiringTime => MessageWithFireTime(m, context.getNextFireTime)
+            case CurrentFiringTime => MessageWithFireTime(m, context.getScheduledFireTime)
+            case PreviousFiringTime => MessageWithFireTime(m, context.getPreviousFireTime)
+            case AllFiringTimes => MessageWithFireTimes(m, Option(context.getPreviousFireTime), Option(context.getScheduledFireTime), Option(context.getNextFireTime))
+            case _ => throw new JobExecutionException("required fire time type is not handled type, must be Next, Current or Previous, was %s".format(f))
+          }
         case any:Any => any
       }
       val log = Logging(logBus, this)


### PR DESCRIPTION
Changes include:
+ Adding the next/previous firing time to the context message allowing users to retrieve next/previous firing time.
+ Test
+ Fixed some formatting inconsistencies
+ Doc cleanup
+ Made tests less sensitive.  I picked 500 ms since it's double the frequency of the max frequency of cron (per second)