### PR TITLE
Update akka version to 2.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ akka-quartz-scheduler
 
 [![Build Status](https://api.travis-ci.org/enragedginger/akka-quartz-scheduler.svg?branch=master)](https://travis-ci.org/enragedginger/akka-quartz-scheduler)
 
-Quartz Extension and utilities for true scheduling in Akka 2.5.x.
+Quartz Extension and utilities for true scheduling in Akka 2.6.x.
 
-Current release is built for Scala 2.13.x and Akka 2.5.x and is available on Maven Central. If you would like support
+Current release is built for Scala 2.13.x and Akka 2.6.x and is available on Maven Central. If you would like support
 for a different combination of Scala and Akka, simply post your request on the issues page (as well as a reason as to
 why the currently available versions won't work for you. I'm always curious about these things).
 
@@ -80,6 +80,9 @@ See CHANGELOG.md for a list of changes by release.
 Usage of the `akka-quartz-scheduler` component first requires including the necessary dependency in your SBT project:
 
 ```scala
+// For Akka 2.6.x and Scala 2.11.x, 2.12.x, 2.13.x
+libraryDependencies += "com.enragedginger" %% "akka-quartz-scheduler" % "1.8.1-akka-2.6.x"
+
 // For Akka 2.5.x and Scala 2.11.x, 2.12.x, 2.13.x
 libraryDependencies += "com.enragedginger" %% "akka-quartz-scheduler" % "1.8.1-akka-2.5.x"
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,17 +2,17 @@ name := "akka-quartz-scheduler"
 
 organization := "com.enragedginger"
 
-version := "1.8.1-akka-2.5.x"
+version := "1.8.1-akka-2.6.x"
 
 scalaVersion in ThisBuild := "2.13.0"
 
 crossScalaVersions := Seq("2.11.8", "2.12.8", "2.13.0")
 
 libraryDependencies ++= Seq(
-    "com.typesafe.akka" %% "akka-actor" % "2.5.23" % "provided",
+    "com.typesafe.akka" %% "akka-actor" % "2.6.0" % "provided",
     "org.quartz-scheduler" % "quartz" % "2.3.0",
     // test dependencies
-    "com.typesafe.akka" %% "akka-testkit" % "2.5.23" % "test",
+    "com.typesafe.akka" %% "akka-testkit" % "2.6.0" % "test",
     "org.specs2" %% "specs2-core" % "4.5.1" % "test",
     "org.specs2" %% "specs2-junit" % "4.5.1" % "test",
     "junit" % "junit" % "4.12" % "test",

--- a/src/main/scala/QuartzSchedulerExtension.scala
+++ b/src/main/scala/QuartzSchedulerExtension.scala
@@ -16,7 +16,12 @@ import scala.collection.JavaConverters._
 import scala.util.control.Exception._
 
 
-object QuartzSchedulerExtension extends ExtensionKey[QuartzSchedulerExtension] {
+object QuartzSchedulerExtension extends ExtensionId[QuartzSchedulerExtension] with ExtensionIdProvider {
+  override def lookup = QuartzSchedulerExtension
+
+  override def createExtension(system: ExtendedActorSystem): QuartzSchedulerExtension =
+    new QuartzSchedulerExtension(system)
+
   override def get(system: ActorSystem): QuartzSchedulerExtension = super.get(system)
 }
 


### PR DESCRIPTION
This addresses https://github.com/enragedginger/akka-quartz-scheduler/issues/89 and updates akka-actor and akka-testkit dependencies to 2.6.0, fixing an issue caused by [ExtensionKey Deprecation](https://doc.akka.io/docs/akka/2.5.3/scala/project/migration-guide-2.4.x-2.5.x.html#extensionkey-deprecation).