### PR TITLE
Remove support for scala 2.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,6 @@ Usage of the `akka-quartz-scheduler` component first requires including the nece
 // For Akka 2.6.x and Scala 2.12.x, 2.13.x
 libraryDependencies += "com.enragedginger" %% "akka-quartz-scheduler" % "1.8.3-akka-2.6.x"
 
-// For Akka 2.6.x and Scala 2.11.x
-libraryDependencies += "com.enragedginger" %% "akka-quartz-scheduler" % "1.8.1-akka-2.6.x"
-
 // For Akka 2.5.x and Scala 2.11.x, 2.12.x, 2.13.x
 libraryDependencies += "com.enragedginger" %% "akka-quartz-scheduler" % "1.8.1-akka-2.5.x"
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ version := "1.8.3-akka-2.6.x"
 
 scalaVersion in ThisBuild := "2.13.1"
 
-crossScalaVersions := Seq("2.11.8", "2.12.8", "2.13.1")
+crossScalaVersions := Seq("2.12.8", "2.13.1")
 
 libraryDependencies ++= Seq(
     "com.typesafe.akka" %% "akka-actor" % "2.6.0" % "provided",


### PR DESCRIPTION
Akka 2.6.0 removes support for scala 2.11, so this project no longer builds under scala 2.11