### PR TITLE
QuartzSchedulerExtension: Allow config to be overridden

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "akka-quartz-scheduler"
 
 organization := "com.enragedginger"
 
-version := "1.8.4-akka-2.6.x"
+version := "1.8.5-akka-2.6.x"
 
 scalaVersion in ThisBuild := "2.13.1"
 

--- a/src/main/scala/QuartzSchedulerExtension.scala
+++ b/src/main/scala/QuartzSchedulerExtension.scala
@@ -5,6 +5,7 @@ import java.util.{Date, TimeZone}
 
 import akka.actor._
 import akka.event.{EventStream, Logging}
+import com.typesafe.config.Config
 import org.quartz._
 import org.quartz.core.jmx.JobDataMapSupport
 import org.quartz.impl.DirectSchedulerFactory
@@ -36,8 +37,9 @@ class QuartzSchedulerExtension(system: ExtendedActorSystem) extends Extension {
   // todo - use of the circuit breaker to encapsulate quartz failures?
   def schedulerName = "QuartzScheduler~%s".format(system.name)
 
-  protected val config = system.settings.config.getConfig("akka.quartz").root.toConfig
+  protected def config: Config = system.settings.config.getConfig("akka.quartz").root.toConfig
 
+  
   // The # of threads in the pool
   val threadCount = config.getInt("threadPool.threadCount")
   require(threadCount >= 1, "Quartz Thread Count (akka.quartz.threadPool.threadCount) must be a positive integer.")


### PR DESCRIPTION
Define a function to get the config so QuartzSchedulerExtension can be extended and getConfig may be overridden.