### PR TITLE
Added Scala 3 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,23 +4,27 @@ organization := "com.enragedginger"
 
 version := "1.9.2-akka-2.6.x"
 
-ThisBuild / scalaVersion := "2.13.5"
+val Scala212Version = "2.12.13"
+val Scala213Version = "2.13.8"
+val Scala3Version = "3.1.3"
 
-crossScalaVersions := Seq("2.12.13", "2.13.5")
+ThisBuild / scalaVersion := Scala213Version
+ThisBuild / crossScalaVersions := Seq(Scala212Version, Scala213Version, Scala3Version)
+ThisBuild / scalacOptions ++= Seq("-language:postfixOps")
 
 libraryDependencies ++= Seq(
-  "com.typesafe.akka"   %% "akka-actor"       % "2.6.10" % "provided",
-  "com.typesafe.akka"   %% "akka-actor-typed" % "2.6.10" % "provided",
+  "com.typesafe.akka"   %% "akka-actor"       % "2.6.19" % "provided",
+  "com.typesafe.akka"   %% "akka-actor-typed" % "2.6.19" % "provided",
   "org.quartz-scheduler" % "quartz"           % "2.3.2"
     exclude ("com.zaxxer", "HikariCP-java7"),
-  "com.typesafe.akka" %% "akka-testkit"             % "2.6.10" % Test,
-  "com.typesafe.akka" %% "akka-actor-testkit-typed" % "2.6.10" % Test,
-  "org.specs2"        %% "specs2-core"              % "4.5.1"  % Test,
-  "org.specs2"        %% "specs2-junit"             % "4.5.1"  % Test,
+  "com.typesafe.akka" %% "akka-testkit"             % "2.6.19" % Test,
+  "com.typesafe.akka" %% "akka-actor-testkit-typed" % "2.6.19" % Test,
+  "org.specs2"        %% "specs2-core"              % "4.15.0" % Test,
+  "org.specs2"        %% "specs2-junit"             % "4.15.0" % Test,
   "junit"              % "junit"                    % "4.12"   % Test,
   "org.slf4j"          % "slf4j-api"                % "1.7.21" % Test,
   "org.slf4j"          % "slf4j-jcl"                % "1.7.21" % Test,
-  "org.scalatest"     %% "scalatest"                % "3.2.6"  % Test
+  "org.scalatest"     %% "scalatest"                % "3.2.12" % Test
 )
 
 resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.3
+sbt.version=1.6.2

--- a/src/main/scala/Implicits.scala
+++ b/src/main/scala/Implicits.scala
@@ -6,11 +6,7 @@ import akka.event.LogSource
  * Package imports, for things like implicits shared across the system.
  */
 object `package` {
-  implicit val quartzExtensionLoggerType: LogSource[QuartzSchedulerExtension] = new LogSource[QuartzSchedulerExtension] {
-    def genString(t: QuartzSchedulerExtension): String = "[" + t.schedulerName + "]"
-  }
+  implicit val quartzExtensionLoggerType: LogSource[QuartzSchedulerExtension] = (t: QuartzSchedulerExtension) => "[" + t.schedulerName + "]"
 
-  implicit val quartzJobLoggerType: LogSource[SimpleActorMessageJob] = new LogSource[SimpleActorMessageJob] {
-    def genString(t: SimpleActorMessageJob): String = "[QuartzJob]"
-  }
+  implicit val quartzJobLoggerType: LogSource[SimpleActorMessageJob] = (_: SimpleActorMessageJob) => "[QuartzJob]"
 }

--- a/src/main/scala/QuartzJob.scala
+++ b/src/main/scala/QuartzJob.scala
@@ -68,7 +68,7 @@ class SimpleActorMessageJob extends Job {
    *
    * @throws JobExecutionException
    */
-  def execute(context: JobExecutionContext) {
+  def execute(context: JobExecutionContext): Unit = {
     implicit val dataMap: JobDataMap = context.getJobDetail.getJobDataMap
     val key  = context.getJobDetail.getKey
 
@@ -88,13 +88,13 @@ class SimpleActorMessageJob extends Job {
             previousFiringTime = Option(context.getPreviousFireTime),
             nextFiringTime = Option(context.getNextFireTime)
           )
-        case any: Any => any
+        case any => any
       }
       val log = Logging(logBus, this)
       log.debug("Triggering job '{}', sending '{}' to '{}'", key.getName, msg, receiver)
       receiver match {
         case ref: ActorRef => ref ! msg
-        case ref: typed.ActorRef[AnyRef] => ref ! msg
+        case ref: typed.ActorRef[_] => ref.asInstanceOf[typed.ActorRef[AnyRef]] ! msg
         case selection: ActorSelection => selection ! msg
         case eventStream: EventStream => eventStream.publish(msg)
         case _ => throw new JobExecutionException("receiver as not expected type, must be ActorRef or ActorSelection, was %s".format(receiver.getClass))

--- a/src/main/scala/QuartzSchedulerTypedExtension.scala
+++ b/src/main/scala/QuartzSchedulerTypedExtension.scala
@@ -32,7 +32,7 @@ class QuartzSchedulerTypedExtension(system: ActorSystem[_]) extends QuartzSchedu
    */
   def createTypedJobSchedule[T](
                          name: String, receiver: ActorRef[T], msg: T, description: Option[String] = None,
-                         cronExpression: String, calendar: Option[String] = None, timezone: TimeZone = defaultTimezone) = {
+                         cronExpression: String, calendar: Option[String] = None, timezone: TimeZone = defaultTimezone): Date = {
     createSchedule(name, description, cronExpression, calendar, timezone)
     scheduleTyped(name, receiver, msg)
   }

--- a/src/main/scala/QuartzSchedules.scala
+++ b/src/main/scala/QuartzSchedules.scala
@@ -119,6 +119,6 @@ final class QuartzCronSchedule(val name: String,
   type T = CronTrigger
 
   // Do *NOT* build, we need the uncompleted builder. I hate the Quartz API, truly.
-  val schedule = CronScheduleBuilder.cronSchedule(expression).inTimeZone(timezone)
+  val schedule: CronScheduleBuilder = CronScheduleBuilder.cronSchedule(expression).inTimeZone(timezone)
 }
 

--- a/src/test/scala/ConfigSpec.scala
+++ b/src/test/scala/ConfigSpec.scala
@@ -8,13 +8,14 @@ import org.specs2.matcher.ThrownExpectations
 import org.specs2.runner.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class ConfigSpec extends Specification with ThrownExpectations { def is =
-  sequential ^
-  "This is a specification of the default configuration of the QuartzSchedulerExtension" ^ p ^
-  "The reference configuration should" ^
-    "contain all default values to setup a thread pool"       ! parseReferenceThreadPool ^
-    "contain the default timezone ID"                         ! parseReferenceTimezone ^
-                                                                end
+class ConfigSpec extends Specification with ThrownExpectations {
+  def is = s2"""
+    This is a specification of the default configuration of the QuartzSchedulerExtension
+
+    The reference configuration should
+      contain all default values to setup a thread pool $parseReferenceThreadPool
+      contain the default timezone ID"                  $parseReferenceTimezone
+    """
 
   lazy val reference = ConfigFactory.load("reference.conf")
 

--- a/src/test/scala/QuartzCalendarSpec.scala
+++ b/src/test/scala/QuartzCalendarSpec.scala
@@ -13,27 +13,26 @@ import scala.collection.JavaConverters._
 import org.quartz.impl.calendar._
 
 @RunWith(classOf[JUnitRunner])
-class QuartzCalendarSpec extends Specification with ThrownExpectations { def is =
-  sequential ^
-  "This is a specification to validate the behavior of the Quartz Calendar configuration modelling"   ^
-                                                            p ^
-  "The configuration parser should"                           ^
-    "Fetch a list of all calendars in a configuration block"  ! parseCalendarList ^
-    "Be able to parse and create an Annual calendar"          ! parseAnnual ^
-    "Be able to parse and create a Holiday calendar"          ! parseHoliday ^
-    "Be able to parse and create a Daily calendar"            ^
-        "With a standard entry"                               ! parseDaily ^
-                                                            p ^
-    "Be able to parse and create a Monthly calendar"          ^
-        "With just one day (a list, but single digit)"        ! parseMonthlyOneDay ^
-        "With a list (multiple digits)"                       ! parseMonthlyList ^
-                                                            p ^
-    "Be able to parse and create a Weekly calendar"           ^
-        "With Ints for Day Names"                             ! parseWeeklyInt ^
-                                                            p ^
-    "Be able to parse and create a Cron calendar"             ! parseCronStyle ^
-                                                                end
+class QuartzCalendarSpec extends Specification with ThrownExpectations {
+  def is = s2"""
+    This is a specification to validate the behavior of the Quartz Calendar configuration modelling
 
+    The configuration parser should
+      Fetch a list of all calendars in a configuration block   $parseCalendarList
+      Be able to parse and create an Annual calendar           $parseAnnual
+      Be able to parse and create a Holiday calendar           $parseHoliday
+      Be able to parse and create a Daily calendar
+          With a standard entry                                $parseDaily
+
+      Be able to parse and create a Monthly calendar
+          With just one day (a list, but single digit)         $parseMonthlyOneDay
+          With a list (multiple digits)                        $parseMonthlyList
+
+      Be able to parse and create a Weekly calendar
+          With Ints for Day Names                              $parseWeeklyInt
+
+      Be able to parse and create a Cron calendar              $parseCronStyle
+    """
 
   def parseCalendarList = {
     //TODO - more robust check
@@ -64,20 +63,18 @@ class QuartzCalendarSpec extends Specification with ThrownExpectations { def is 
     cal.isDayExcluded(getCalendar(DECEMBER, 31, 2075)) must beFalse
   }
 
- def parseHoliday = {
-   calendars must haveKey("Easter")
-   calendars("Easter") must haveClass[HolidayCalendar]
+  def parseHoliday = {
+    calendars must haveKey("Easter")
+    calendars("Easter") must haveClass[HolidayCalendar]
 
-   calendars("Easter").asInstanceOf[HolidayCalendar].getExcludedDates.asScala must containAllOf(List(
-     getDate(2013, 3, 31),
-     getDate(2014, 4, 20),
-     getDate(2015, 4,  5),
-     getDate(2016, 3, 27),
-     getDate(2017, 4, 16)
-   ))
-
- }
-
+    calendars("Easter").asInstanceOf[HolidayCalendar].getExcludedDates.asScala must containAllOf(List(
+      getDate(2013, 3, 31),
+      getDate(2014, 4, 20),
+      getDate(2015, 4,  5),
+      getDate(2016, 3, 27),
+      getDate(2017, 4, 16)
+    ))
+  }
 
   def parseDaily = {
     calendars must haveKey("HourOfTheWolf")

--- a/src/test/scala/QuartzScheduleSpec.scala
+++ b/src/test/scala/QuartzScheduleSpec.scala
@@ -13,14 +13,14 @@ import org.quartz.TriggerUtils
 import scala.collection.JavaConverters._
 
 @RunWith(classOf[JUnitRunner])
-class QuartzScheduleSpec extends Specification with ThrownExpectations { def is =
-  sequential ^
-  "This is a specification to validate the behavior of the Quartz Schedule configuration parser" ^
-    "The configuration parser should"                            ^
-      "Fetch a list of all schedules in the configuration block" ! parseScheduleList ^
-      "Be able to parse out a cron schedule"                     ! parseCronSchedule ^
-      "Be able to parse out a cron schedule w/ calendars"        ! parseCronScheduleCalendars ^
-                                                                   end
+class QuartzScheduleSpec extends Specification with ThrownExpectations {
+  def is = s2"""
+    This is a specification to validate the behavior of the Quartz Schedule configuration parser
+      The configuration parser should
+        Fetch a list of all schedules in the configuration block $parseScheduleList
+        Be able to parse out a cron schedule                     $parseCronSchedule
+        Be able to parse out a cron schedule w/ calendars        $parseCronScheduleCalendars
+    """
 
   def parseScheduleList = {
     schedules must haveSize(2)


### PR DESCRIPTION
The library can now be cross-built with Scala 2.12, 2.13 and 3.1. To achieve this, some modifications had to be made:

- update sbt version
- update all Scala dependencies to latest versions (especially Akka)
- udate Specs2 Acceptance tests to recent syntax

Additionally, some return types have been made explicit